### PR TITLE
fix: onPairListDevices usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /node_modules/
 /.homeybuild/
 .DS_Store
+.idea/

--- a/drivers/echo/driver.ts
+++ b/drivers/echo/driver.ts
@@ -39,17 +39,15 @@ module.exports = class EchoDriver extends Homey.Driver {
       .registerRunListener((args, _state) => this.api.executeRoutine(args.device.id, args.routine.id));
   }
 
-  async onPair(session: Homey.Driver.PairSession): Promise<void> {
-    if (!this.api.connected) {
-      throw new Error('Please check the connection to your Amazon account in the app settings');
-    }
-  }
-
   /**
    * onPairListDevices is called when a user is adding a device and the 'list_devices' view is called.
    * This should return an array with the data of devices that are available for pairing.
    */
   async onPairListDevices() {
+    if (!this.api.connected) {
+      throw new Error('Please check the connection to your Amazon account in the app settings');
+    }
+
     const devices = await this.api.getDevices();
 
     return devices

--- a/drivers/echo/driver.ts
+++ b/drivers/echo/driver.ts
@@ -39,15 +39,21 @@ module.exports = class EchoDriver extends Homey.Driver {
       .registerRunListener((args, _state) => this.api.executeRoutine(args.device.id, args.routine.id));
   }
 
+  async onPair(session: Homey.Driver.PairSession): Promise<void> {
+    if (!this.api.connected) {
+      throw new Error('Please check the connection to your Amazon account in the app settings');
+    }
+
+    session.setHandler("list_devices", async () => {
+      return await this.onPairListDevices();
+    });
+  }
+
   /**
    * onPairListDevices is called when a user is adding a device and the 'list_devices' view is called.
    * This should return an array with the data of devices that are available for pairing.
    */
   async onPairListDevices() {
-    if (!this.api.connected) {
-      throw new Error('Please check the connection to your Amazon account in the app settings');
-    }
-
     const devices = await this.api.getDevices();
 
     return devices


### PR DESCRIPTION
For me `onPairListDevices` was not called. Instead there was an error while rendering **list_devices** template with error **null is not an object (evaluating 'devices.length')**

I guess using only `onPairListDevices` method is good enough as stated [here](https://apps.developer.homey.app/the-basics/devices/pairing#basic-pairing-example). For me it works fine.